### PR TITLE
Workaround for Select2 bug.

### DIFF
--- a/assets/js/input.js
+++ b/assets/js/input.js
@@ -8,7 +8,6 @@
 		 */
 		if ( $el.find('select').length > 0 ) {
 			var $select = $el.find('select'),
-				$multiple = $select.data('multiple'),
 				$placeholder = $select.data('placeholder'),
 				$allow_null = $select.data('allow_null');
 

--- a/assets/js/input.js
+++ b/assets/js/input.js
@@ -12,6 +12,15 @@
 				$placeholder = $select.data('placeholder'),
 				$allow_null = $select.data('allow_null');
 
+			// Before the Select2 field is initialized, remove of the `data-ajax` data
+			// attribute on the <select> field that ACF generates, as that data
+			// attribute causes Select2 to expect AJAX functionality that this plugin
+			// does not provide. This is a workaround to fix functionality until this
+			// plugin is re-written.
+			// Relevant issue: https://github.com/jonathan-dejong/acf-sites/issues/6
+			$select.removeAttr('data-ajax');
+
+			// Initialize the Select2 field.
 			$select.select2({
 				width:				'100%',
 				containerCssClass:	'-acf',


### PR DESCRIPTION
This plugin still works except for a bug where Select2 tries to initialize the `<select>` with AJAX functionality when it shouldn't. (See #6.)

This PR fixes that bug so that this plugin can be used immediately after download and installation. Otherwise, one must manually patch the plugin file after downloading, which is bad for a few reasons: 1) it's difficult to discover the fix for the bug, 2) patching the plugin file is tedious, 3) the plugin could be overwritten or its changes not shared with other developers, and 4) doing this patch may be difficult for some developers.

Although a full rewrite of this plugin would be nice (as the developer suggests in the comments for #6), it's not necessary to fix this bug.